### PR TITLE
Add relative path to `types.ts` import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import cp from 'node:child_process'
 import { download as downloadDriver } from './install.js'
 import { hasAccess, parseParams } from './utils.js'
 import { BINARY_FILE } from './constants.js'
-import type { GeckodriverParameters } from 'types.js'
+import type { GeckodriverParameters } from './types.js'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 


### PR DESCRIPTION
This non-relative import breaks some of the more strict type-checking systems :)

e.g.,:
```
build-system/tasks/e2e/node_modules/geckodriver/dist/index.d.ts:4:44 - error TS2307: Cannot find module 'types.js' or its corresponding type declarations.

4 import type { GeckodriverParameters } from 'types.js';
```