### PR TITLE
Update the bin-script reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ]
   },
   "bin": {
-    "geckodriver": "./bin/geckodriver"
+    "geckodriver": "./bin/geckodriver.js"
   },
   "bugs": {
     "url": "https://github.com/webdriverio-community/node-geckodriver/issues"


### PR DESCRIPTION
Partial fix to the issue https://github.com/webdriverio-community/node-geckodriver/issues/123. With it [in place](https://github.com/marcin-wosinek/geckodriver-test/tree/main/fix), the bin script still fails, but with another error:
```
$ npx geckodriver --port=4444
node:internal/errors:490
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/marcinwosinek/workspace/geckodriver-test/fix/node_modules/geckodriver/dist/cli.js' imported from /Users/marcinwosinek/workspace/geckodriver-test/fix/node_modules/geckodriver/bin/geckodriver.js
    at new NodeError (node:internal/errors:399:5)
    at finalizeResolution (node:internal/modules/esm/resolve:326:11)
    at moduleResolve (node:internal/modules/esm/resolve:945:10)
    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v18.15.0
```

The file is missing, because the project was not build. I'm not sure what is the best-practice solution for it.