### PR TITLE
drivers: Document websocket-port arg, set it to random

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,13 @@ export async function start (params: GeckodriverParameters) {
   }
 
   startArgs.host = startArgs.host || DEFAULT_HOSTNAME
+
+  // By default, Geckodriver uses port 9222
+  // User might pass a port for custom runs but they should modify them for each worker
+  // For remaining use cases, to enable parallel instances we need to set the port to 0 (random)
+  // Otherwise all instances try to connect to the default port and fail
+  startArgs.websocketPort = startArgs.websocketPort ?? 0;
+  
   const args = parseParams(startArgs)
   log.info(`Starting Geckodriver at ${geckoDriverPath} with params: ${args.join(' ')}`)
   return cp.spawn(geckoDriverPath, args)

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,10 @@ export interface GeckodriverParameters {
    */
   port?: number
   /**
+   * port to use for Debugger / Webdriver BiDi
+   */
+  websocketPort?: number
+  /**
    * Directory in which to create profiles. Defaults to the system temporary directory.
    */
   profileRoot?: string


### PR DESCRIPTION
There is an undocumented argument (`--websocket-port`) to pass to `geckodriver`, according to https://github.com/mozilla/geckodriver/issues/2011#issuecomment-1121983657

This change documents it and sets it to random (port zero) for new sessions.
Previously if none was set, the default (9222) would be used.

This would pose an issue when users specified `webSocketUrl` capability as N instances running in parallel would try to connect to the default port and fail.

Allows for WebDriver BiDi / CDP - enabled parallel runs for Firefox with the [webdriverIO](https://github.com/webdriverio/webdriverio) project.

Fixes https://github.com/webdriverio/webdriverio/issues/10839
