### PR TITLE
Fix bug when specifying customGeckoDriverPath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-unicorn": "^48.0.0",
+        "geckodriver": ".",
         "husky": "^8.0.3",
         "npm-run-all": "^4.1.5",
         "octokit": "^3.0.0",
@@ -5184,42 +5185,8 @@
       }
     },
     "node_modules/geckodriver": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.0.tgz",
-      "integrity": "sha512-I2BlybeMFMzpxHRrh8X4VwP4ys74JHszyUgfezOrbTR7PEybFneDcuEjKIQxKV6vFPmsdwhwF1x8AshdQo56xA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@wdio/logger": "^8.11.0",
-        "decamelize": "^6.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.1",
-        "tar-fs": "^3.0.4",
-        "unzipper": "^0.10.14",
-        "which": "^3.0.1"
-      },
-      "bin": {
-        "geckodriver": "bin/geckodriver.js"
-      },
-      "engines": {
-        "node": "^16.13 || >=18 || >=20"
-      }
-    },
-    "node_modules/geckodriver/node_modules/which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
+      "resolved": "",
+      "link": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-unicorn": "^48.0.0",
+    "geckodriver": ".",
     "husky": "^8.0.3",
     "npm-run-all": "^4.1.5",
     "octokit": "^3.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ import { DEFAULT_HOSTNAME, log } from './constants.js'
 import type { GeckodriverParameters } from './types.js'
 
 export async function start (params: GeckodriverParameters) {
-  const { cacheDir, ...startArgs } = params
-  let geckoDriverPath = process.env.GECKODRIVER_FILEPATH || params.customGeckoDriverPath
+  const { cacheDir, customGeckoDriverPath, ...startArgs } = params
+  let geckoDriverPath = process.env.GECKODRIVER_FILEPATH || customGeckoDriverPath
   if (!geckoDriverPath) {
     geckoDriverPath = await downloadDriver(params.geckoDriverVersion, cacheDir)
   }
@@ -22,8 +22,8 @@ export async function start (params: GeckodriverParameters) {
   // User might pass a port for custom runs but they should modify them for each worker
   // For remaining use cases, to enable parallel instances we need to set the port to 0 (random)
   // Otherwise all instances try to connect to the default port and fail
-  startArgs.websocketPort = startArgs.websocketPort ?? 0;
-  
+  startArgs.websocketPort = startArgs.websocketPort ?? 0
+
   const args = parseParams(startArgs)
   log.info(`Starting Geckodriver at ${geckoDriverPath} with params: ${args.join(' ')}`)
   return cp.spawn(geckoDriverPath, args)

--- a/tests/test.e2e.js
+++ b/tests/test.e2e.js
@@ -1,16 +1,63 @@
 import waitPort from 'wait-port'
 import { remote } from 'webdriverio'
 
-import { start } from '../dist/index.js'
+import { download, start } from '../dist/index.js'
+
+// start geckodriver automatically
+console.log('= start geckodriver automatically =')
+try {
+  const browser = await remote({
+    automationProtocol: 'webdriver',
+    capabilities: {
+      browserName: 'firefox',
+      'moz:firefoxOptions': {
+        args: ['-headless']
+      }
+    }
+  })
+  await browser.url('https://webdriver.io')
+  await browser.deleteSession()
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}
+
+// start specific geckodriver
+console.log('= start specific geckodriver =')
+
+const binary = await download()
+
+try {
+  const browser = await remote({
+    automationProtocol: 'webdriver',
+    capabilities: {
+      browserName: 'firefox',
+      'moz:firefoxOptions': {
+        args: ['-headless']
+      },
+      'wdio:geckodriverOptions': {
+        binary
+      }
+    }
+  })
+  await browser.url('https://webdriver.io')
+  await browser.deleteSession()
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}
+
+// start geckodriver manually
+console.log('= start geckodriver manually =')
 
 const port = 4444
 const cp = await start({ port })
 
 try {
-  await waitPort({ port: 4444 })
+  await waitPort({ port })
   const browser = await remote({
     automationProtocol: 'webdriver',
-    hostname: '0.0.0.0',
+    port, // must set port or wdio will automatically start geckodriver
     capabilities: {
       browserName: 'firefox',
       'moz:firefoxOptions': {


### PR DESCRIPTION
WHAT?

Destructured `customGeckoDriverPath` out of `params` in `function start()`.

Additionally, updated `test.e2e.js` to test the three `webdriver` usage modes: 1/ automatically download and start, 2/ automatically start, 3/ manually start.

Finally, added a self-referencing `devDependency` to `geckodriver` since `webdriverio` transitively depends on it.

WHY?

Before this change, running the following code:

```ts
import { start } from 'geckodriver'

await start({ customGeckoDriverPath: '/some/path/geckodriver' })
```

Would fail to start the `geckodriver` because it would execute:

```shell
geckodriver --custom-gecko-driver-path=/some/path/geckodriver --port=43083 --host=0.0.0.0 --websocket-port=0
```

Which results in exit code `64` and the following output:

```log
/some/path/geckodriver: error: Found argument '--custom-gecko-driver-path' which wasn't expected, or isn't valid in this context

If you tried to supply `--custom-gecko-driver-path` as a value rather than a flag, use `-- --custom-gecko-driver-path`

USAGE:
    geckodriver [OPTIONS]

For more information try --help
```

By destructuring `customGeckoDriverPath`, the extraneous `--custom-gecko-driver-path` argument is no longer specified and the webdriver starts successfully.

HOW?

Successfully ran:

```shell
npm run build && npm test
```