### PR TITLE
Remove `/// <reference` line in `postbuild`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "tsc -b .",
+    "postbuild": "sed -i '1{/^\\/\\/\\/ <reference/d}' dist/index.d.ts",
     "clean": "rimraf ./node_modules package-lock.yaml ./dist",
     "prepare": "husky install",
     "postinstall": "test -f ./dist/install.js && node ./dist/install.js || echo \"Skipping install, project not build!\"",


### PR DESCRIPTION
Fixes #311

Admittedly this is a little bit of a hack, but in its defense:
- I protect the removal using the regex that ensures it only removes the first line, and only if it starts with `/// <reference`
- This reference line isn't useful, since the generated code explicitly imports all the `node` modules that it uses

I honestly think it's a bug in tsc, but I couldn't find anything relevant in their repo :/