### PR TITLE
Fix installer not respecting GECKODRIVER_AUTO_INSTALL variable

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -98,7 +98,7 @@ function downloadZip(body: NodeJS.ReadableStream, cacheDir: string) {
 /**
  * download on install
  */
-if (process.argv[1] && process.argv[1].endsWith('/dist/install.js') && Boolean(process.env.GECKODRIVER_AUTO_INSTALL || '1')) {
+if (process.argv[1] && process.argv[1].endsWith('/dist/install.js') && process.env.GECKODRIVER_AUTO_INSTALL) {
   await download().then(
     () => log.info('Success!'),
     (err) => log.error(`Failed to install Geckodriver: ${err.stack}`)


### PR DESCRIPTION
The readme states that
> By default, this package downloads Geckodriver when used for the first time through the CLI or the programmatic interface. If you like to download it as part of the NPM install process, set the GECKODRIVER_AUTO_INSTALL environment flag, e.g.:

However, `Boolean(process.env.GECKODRIVER_AUTO_INSTALL || '1')` will always be `true` regardless of the `GECKODRIVER_AUTO_INSTALL` variable, meaning it will always download the driver during installation process.

This PR fixes the env var detection