### PR TITLE
feat: support spawnOpts for geckodriver child process

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Firefox to spawn with `MOZ_` prefix variables, such as `MOZ_HEADLESS_WIDTH`.
 See https://nodejs.org/api/child_process.html#child_processspawncommand-args-options for
 all options.
 
-Type: `[key: string]: string`<br />
+Type: `SpawnOptionsWithoutStdio | SpawnOptionsWithStdioTuple`<br />
 Default: `undefined`
 
 # Other Browser Driver

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ The path to the root of the cache directory.
 Type: `string`<br />
 Default: `process.env.GECKODRIVER_CACHE_DIR || os.tmpdir()`
 
+### `spawnOpts`
+Options to pass into the geckodriver process. This can be useful if needing
+Firefox to spawn with `MOZ_` prefix variables, such as `MOZ_HEADLESS_WIDTH`.
+See https://nodejs.org/api/child_process.html#child_processspawncommand-args-options for
+all options.
+
+Type: `[key: string]: string`<br />
+Default: `undefined`
+
 # Other Browser Driver
 
 If you also look for other browser driver NPM wrappers, you can find them here:

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type { GeckodriverParameters } from './types.js'
 const log = logger('geckodriver')
 
 export async function start (params: GeckodriverParameters) {
-  const { cacheDir, customGeckoDriverPath, ...startArgs } = params
+  const { cacheDir, customGeckoDriverPath, spawnOpts, ...startArgs } = params
   let geckoDriverPath = (
     customGeckoDriverPath ||
     process.env.GECKODRIVER_PATH ||
@@ -42,7 +42,7 @@ export async function start (params: GeckodriverParameters) {
 
   const args = parseParams(startArgs)
   log.info(`Starting Geckodriver at ${geckoDriverPath} with params: ${args.join(' ')}`)
-  return cp.spawn(geckoDriverPath, args)
+  return cp.spawn(geckoDriverPath, args, spawnOpts)
 }
 
 export const download = downloadDriver

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
+import type { SpawnOptionsWithoutStdio, SpawnOptionsWithStdioTuple, StdioPipe, StdioNull } from 'node:child_process'
+
 export type LogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'config' | 'debug' | 'trace'
 
-type SpawnOpt = { [key: string]: string | string[] | SpawnOpt }
-
+type StdioOption = StdioNull | StdioPipe
 export interface GeckodriverParameters {
   /**
    * List of hostnames to allow. By default the value of --host is allowed, and in addition if that's a well
@@ -85,7 +86,7 @@ export interface GeckodriverParameters {
    * @see options in https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
    * @default undefined
    */
-  spawnOpts?: SpawnOpt
+  spawnOpts?: SpawnOptionsWithoutStdio | SpawnOptionsWithStdioTuple<StdioOption, StdioOption, StdioOption>
 }
 
 declare global {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,11 @@ export interface GeckodriverParameters {
    */
   cacheDir?: string
 
+  /**
+   * options to be passed into the process.
+   * @see options in https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
+   * @default undefined
+   */
   spawnOpts?: SpawnOpt
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type LogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'config' | 'debug' | 'trace'
 
+type SpawnOpt = { [key: string]: string | string[] | SpawnOpt }
+
 export interface GeckodriverParameters {
   /**
    * List of hostnames to allow. By default the value of --host is allowed, and in addition if that's a well
@@ -77,6 +79,8 @@ export interface GeckodriverParameters {
    * @default process.env.GECKODRIVER_CACHE_DIR || os.tmpdir()
    */
   cacheDir?: string
+
+  spawnOpts?: SpawnOpt
 }
 
 declare global {

--- a/tests/start-unit.test.ts
+++ b/tests/start-unit.test.ts
@@ -1,0 +1,41 @@
+
+import cp from 'node:child_process'
+import { vi, test, expect } from 'vitest'
+import { type GeckodriverParameters, start } from '../src/index.ts'
+
+test('start', async () => {
+  vi.mock('../src/install.js', () =>  {
+    return {
+      download: vi.fn().mockResolvedValue('foo')
+    }
+  })
+
+  vi.mock('../src/utils.js', async (original) =>  {
+    const actual: any = await original()
+    return {
+      hasAccess: vi.fn().mockResolvedValue(true),
+      parseParams: actual.parseParams
+    }
+  })
+
+  vi.mock('node:child_process', () => ({
+    default: {
+      spawn: vi.fn(),
+    }
+  }))
+
+  const args: GeckodriverParameters  = {
+    spawnOpts: {
+      env: {
+        MOZ_HEADLESS_WIDTH: '720'
+      }
+    }
+  }
+
+  await start(args)
+  expect(cp.spawn).toHaveBeenCalledWith('foo', ['--host=0.0.0.0', '--websocket-port=0'], {
+    env: {
+      MOZ_HEADLESS_WIDTH: '720'
+    }
+  })
+})


### PR DESCRIPTION
I am currently migrating Cypress to use `webdriver` and `geckodriver` for our firefox automation. We have the needs to propagate some environment variables to the geckodriver process (better outlined in this bugzilla [comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1604723#c20)), which we are patching this package to accomplish now. This PR is to move this patch upstream as a contribution.

In order to propagate environment variables to the firefox process started with `geckodriver`, the environment variables need to be passed to the `geckodriver` process directly in order to be passed to `firefox`. This is important for setting `MOZ_` prefixed variables, like `MOZ_HEADLESS_HEIGHT` or `MOZ_HEADLESS_WIDTH`. This PR allows spawn options to be passed into the geckodriver process. 

