### PR TITLE
fix: correct type on gecko driver params to be logNoTruncate instead of logNoTruncated

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface GeckodriverParameters {
   /**
    * write server log to file instead of stderr, increases log level to INFO
    */
-  logNoTruncated?: boolean
+  logNoTruncate?: boolean
   /**
    * Host to use to connect to Gecko
    * @default 127.0.0.1


### PR DESCRIPTION
Fixes the `logNoTruncated` typing to be `logNoTruncate`. This can be seen when running `geckodriver --help`

<img width="541" alt="Screenshot 2024-10-09 at 3 04 00 PM" src="https://github.com/user-attachments/assets/947efe93-6f0c-4d6b-a0c8-e056fc336c4b">
