### PR TITLE
chore: update prepare script for Husky 9 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "tsc -b .",
     "clean": "rimraf ./node_modules package-lock.yaml ./dist",
-    "prepare": "husky install",
+    "prepare": "husky",
     "postinstall": "test -f ./dist/install.js && node ./dist/install.js || echo \"Skipping install, project not build!\"",
     "test": "run-s build test:*",
     "test:lint": "eslint",


### PR DESCRIPTION
The previous prepare script used `husky install`, which is deprecated in Husky 9. Updated to use `husky` as recommended.


This will fix the depreciation warnings like in this CI build: https://github.com/webdriverio-community/node-geckodriver/actions/runs/15976775551/job/45061223970#step:4:14