### PR TITLE
refactor!: remove node-fetch; require Node.js >=20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "decamelize": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
-        "node-fetch": "^3.3.2",
         "tar-fs": "^3.0.6"
       },
       "bin": {
@@ -41,7 +40,7 @@
         "webdriverio": "^9.4.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3807,6 +3806,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4800,6 +4800,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4904,6 +4905,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -6334,6 +6336,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6353,6 +6356,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -8819,6 +8823,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "geckodriver",
@@ -81,7 +81,6 @@
     "decamelize": "^6.0.0",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.5",
-    "node-fetch": "^3.3.2",
     "tar-fs": "^3.0.6"
   }
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,3 +1,5 @@
+import type { Agent as HttpAgent } from 'node:http'
+import type { Agent as HttpsAgent } from 'node:https'
 import os from 'node:os'
 import path from 'node:path'
 import util from 'node:util'
@@ -7,7 +9,6 @@ import zlib from 'node:zlib'
 
 import logger from '@wdio/logger'
 import tar from 'tar-fs'
-import { type RequestInit } from 'node-fetch'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { HttpProxyAgent } from 'http-proxy-agent'
 
@@ -19,7 +20,9 @@ import { BlobReader, BlobWriter, ZipReader } from '@zip.js/zip.js'
 const log = logger('geckodriver')
 const streamPipeline = util.promisify(stream.pipeline)
 
-const fetchOpts: RequestInit = {}
+const fetchOpts: RequestInit & {
+    agent?: HttpAgent | HttpsAgent | InstanceType<typeof HttpsProxyAgent> | InstanceType<typeof HttpProxyAgent>
+} = {}
 if (process.env.HTTPS_PROXY) {
     fetchOpts.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY)
 } else if (process.env.HTTP_PROXY) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import util from 'node:util'
 import fs from 'node:fs/promises'
 
 import decamelize from 'decamelize'
-import fetch, { type RequestInit } from 'node-fetch'
 
 import { GECKODRIVER_DOWNLOAD_PATH } from './constants.js'
 import type { GeckodriverParameters } from './types.js'
@@ -46,7 +45,7 @@ export function parseParams(params: GeckodriverParameters) {
         .filter(Boolean)
 }
 
-export async function retryFetch(url: string, opts: RequestInit, retry: number = 3) {
+export async function retryFetch(url: string, opts: RequestInit = {}, retry = 3): Promise<Response> {
     while (retry > 0) {
         try {
             return await fetch(url, opts)
@@ -55,10 +54,10 @@ export async function retryFetch(url: string, opts: RequestInit, retry: number =
             if (retry === 0) {
                 throw e
             }
-
             await sleep(RETRY_DELAY)
         }
     }
+    throw new Error('Failed to fetch after retries')
 }
 
 function sleep(ms: number) {


### PR DESCRIPTION
BREAKING CHANGE: Node.js 20 or higher is now required. Node.js 18 reached end-of-life in April 2025.

Replace node-fetch with the built-in fetch API available in Node.js 20+. This reduces bundle size and avoids deprecation warnings related to node-domexception. node-fetch hasn't seen much active development lately, and the built-in fetch API makes it largely redundant.

Verified by successful CI workflow run: https://github.com/YasharF/node-geckodriver/actions/runs/16865975050