### PR TITLE
fix: correct postinstall script typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "tsc -b .",
     "clean": "rimraf ./node_modules package-lock.yaml ./dist",
     "prepare": "husky",
-    "postinstall": "test -f ./dist/install.js && node ./dist/install.js || echo \"Skipping install, project not build!\"",
+    "postinstall": "test -f ./dist/install.js && node ./dist/install.js || echo \"Skipping install, project not built!\"",
     "test": "run-s build test:*",
     "test:lint": "eslint",
     "test:unit": "vitest --run",


### PR DESCRIPTION
## Situation

The `postinstall` script definition

https://github.com/webdriverio-community/node-geckodriver/blob/c509f9f847d5c99a61be278b2b70b5452357e805/package.json#L34

contains a typo in the text "Skipping install, project not build!"
"build" should be "built" (see https://www.merriam-webster.com/dictionary/build).

## Change

Change "build" to "built" in the `postinstall` script definition in [package.json](https://github.com/webdriverio-community/node-geckodriver/blob/main/package.json).

## Verify

Ubuntu `24.04.3` LTS, Node.js `22.18.0` LTS

```shell
git clone https://github.com/webdriverio-community/node-geckodriver
git clean -xfd # if repeating
npm ci
```

and confirm that the message:

> Skipping install, project not built!

is output.
