### PR TITLE
chore: add geckodriver@5.0.0 to lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
     "": {
       "name": "geckodriver",
       "version": "6.0.0",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3496,6 +3497,30 @@
       },
       "engines": {
         "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/geckodriver": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-5.0.0.tgz",
+      "integrity": "sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.1.3",
+        "@zip.js/zip.js": "^2.7.53",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^3.3.2",
+        "tar-fs": "^3.0.6",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@zip.js/zip.js": {


### PR DESCRIPTION
- closes https://github.com/webdriverio-community/node-geckodriver/issues/659

## Situation

`npm ci` fails with error:

> npm error Missing: geckodriver@5.0.0 from lock file

`geckodriver@5.0.0` is required as a transitive dependency of [webdriverio@9.19.1](https://github.com/webdriverio/webdriverio/releases/tag/v9.19.1)

## Change

Execute `npm install` to update `package-lock.json`

## Verification

| Component | Version       |
| --------- | ------------- |
| Ubuntu    | `24.04.3` LTS |
| Node.js   | `20.19.4`     |

```shell
git clone https://github.com/webdriverio-community/node-geckodriver
cd node-geckodriver
git clean -xfd # if repeating
npm ci
```
