### PR TITLE
fix: enable GECKODRIVER_AUTO_INSTALL usage on Windows

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -88,7 +88,12 @@ async function downloadZip(res: Awaited<ReturnType<typeof retryFetch>>, cacheDir
 /**
  * download on install
  */
-if (process.argv[1] && process.argv[1].endsWith('/dist/install.js') && process.env.GECKODRIVER_AUTO_INSTALL) {
+const installJsPath = path.join('dist', 'install.js')
+if (
+    process.argv[1] &&
+    path.normalize(process.argv[1]).endsWith(path.sep + installJsPath) &&
+    process.env.GECKODRIVER_AUTO_INSTALL
+) {
     await download().then(
         () => log.info('Success!'),
         (err) => log.error(`Failed to install Geckodriver: ${err.stack}`)


### PR DESCRIPTION
- closes https://github.com/webdriverio-community/node-geckodriver/issues/653

## Situation

The [README > Installing section](https://github.com/webdriverio-community/node-geckodriver/blob/main/README.md#installing) describes how the environment variable `GECKODRIVER_AUTO_INSTALL` can be set to `1` to request that Geckodriver is installed during dependency installation through a package manager such as npm.

This does not work in a Microsoft Windows environment. Executing `npm install geckodriver` with the above environment variable set does not cause Geckodriver to be downloaded.

The check for the calling JavaScript filename `/dist/install.js` in [src/install.ts](https://github.com/webdriverio-community/node-geckodriver/blob/main/src/install.ts) assumes POSIX style paths with forward slash (`/`) separators and does not take account of Windows style path separators using backslash (`\`).

## Change

Use Node.js [path](https://nodejs.org/docs/latest/api/path.html) methods to normalize the file path comparison.

[src/install.ts](https://github.com/webdriverio-community/node-geckodriver/blob/main/src/install.ts) is modified accordingly.

## Verification

### Windows

| Component       | Version       |
| --------------- | ------------- |
| Windows         | `11 24H2`       |
| Node.js         | `22.18.0` LTS |
| Git for Windows | `2.50.1`      |

In a Git Bash terminal window execute the following:

```shell
cd $(mktemp -d)
git clone --branch auto-install-cross-env https://github.com/MikeMcC399/node-geckodriver
cd node-geckodriver
npm install
npm run build
cd ..
mkdir install-test
cd install-test
rm -rf /tmp/geckodriver* # delete any pre-existing installed driver
GECKODRIVER_AUTO_INSTALL=1 npm install ../node-geckodriver
rm -rf node_modules package*.json # clean up after test
```

Then use the following command to check if a driver was already installed. If the driver is already installed, it will log the installed version. If there is no driver installed, then it attempts to install a driver:

```shell
npx geckodriver --version # check if the driver was installed
```

#### Windows cmd

Following on from the Git Bash test and in the same directory:

```shell
cmd
```

```shell
DEL %TEMP%\geckodriver.exe
SET GECKODRIVER_AUTO_INSTALL=1
npm install ..\node-geckodriver
npx geckodriver --version
```

then

```shell
exit
```


Clean up in Git Bash

```shell
rm -rf node_modules package*.json # clean up after test
```

#### PowerShell

Again, following on from the Git Bash test or Windows cmd test and in the same directory:

```shell
powershell
```

```shell
Remove-Item "$env:TEMP/geckodriver.exe" -Force
$env:GECKODRIVER_AUTO_INSTALL=1
npm install ..\node-geckodriver
npx geckodriver --version
```

then

```shell
exit
```

### Linux

Check that there is no regression for Linux

| Component | Version       |
| --------- | ------------- |
| Ubuntu    | `24.04.3` LTS |
| Node.js   | `22.18.0` LTS |

Same instructions as above for Windows Git Bash.
