### PR TITLE
ci: extend CI tests to Node.js 22 and 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,20 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        node: # Node.js version https://github.com/nodejs/release#release-schedule
+          - 20 # Maintenance LTS
+          - 22 # Active LTS
+          - 24 # Current
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: 💚 Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
       - name: 🚧 Install Dependencies
         run: npm ci
       - name: 📦 Build


### PR DESCRIPTION
- implements suggestion from https://github.com/webdriverio-community/node-geckodriver/issues/661#issuecomment-3218266543

## Situation

The workflow [.github/workflows/ci.yml](https://github.com/webdriverio-community/node-geckodriver/blob/main/.github/workflows/ci.yml) tests in CI using Node.js 20 only. This does not test the other currently [supported Node.js versions](https://nodejs.org/en/about/previous-releases) 22 and 24.

## Change

- Add a matrix of Node.js 20, 22 & 24 to the workflow [.github/workflows/ci.yml](https://github.com/webdriverio-community/node-geckodriver/blob/main/.github/workflows/ci.yml)

- Add `fail-fast: false` to give a better overall matrix picture in failure situations