### PR TITLE
chore: resync lockfile after geckodriver 5.0.0 dev addition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "geckodriver",
       "version": "6.0.1",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Situation

Although running `npm ci` executes without error, which usually means that the [package-lock.json](https://github.com/webdriverio-community/node-geckodriver/blob/main/package-lock.json) is fully up-to-date,  if `npm install` is executed, it removes the `dev` key from the active `geckodriver@6.0.1` entry in [package-lock.json](https://github.com/webdriverio-community/node-geckodriver/blob/main/package-lock.json):

```text
$ git diff
diff --git a/package-lock.json b/package-lock.json
index 3729db4..17c9e5b 100644
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "geckodriver",
       "version": "6.0.1",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
```

The fact that npm put the `dev` key into this entry in PR https://github.com/webdriverio-community/node-geckodriver/pull/660 is probably due to a bug in npm, as it shouldn't be necessary to run `npm install` twice in order to reach a stable end-state. Combining an earlier version of `geckodriver` in `devDependencies` seems to have confused npm. It's an unusual situation. Unfortunately I also didn't anticipate or notice this error at the time.

## Change

Run `npm install` and commit the change.

## Verification

```shell
git clone https://github.com/webdriverio-community/node-geckodriver
cd node-geckodriver
git clean -xfd # if repeating
npm ci
```

Confirm no error from `npm ci`

```shell
npm install
git diff
```

Confirm no change caused by `npm install`
