### PR TITLE
fix: do not forward geckoDriverVersion as a CLI argument to geckodriver binary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type { GeckodriverParameters } from './types.js'
 const log = logger('geckodriver')
 
 export async function start (params: GeckodriverParameters): Promise<ChildProcess> {
-    const { cacheDir, customGeckoDriverPath, spawnOpts, ...startArgs } = params
+    const { cacheDir, customGeckoDriverPath, spawnOpts, geckoDriverVersion, ...startArgs } = params
     let geckoDriverPath = (
         customGeckoDriverPath ||
     process.env.GECKODRIVER_PATH ||
@@ -17,7 +17,7 @@ export async function start (params: GeckodriverParameters): Promise<ChildProces
     process.env.GECKODRIVER_FILEPATH
     )
     if (!geckoDriverPath) {
-        geckoDriverPath = await downloadDriver(params.geckoDriverVersion, cacheDir)
+        geckoDriverPath = await downloadDriver(geckoDriverVersion, cacheDir)
     }
 
     if (!(await hasAccess(geckoDriverPath))) {

--- a/tests/start-unit.test.ts
+++ b/tests/start-unit.test.ts
@@ -2,6 +2,7 @@
 import cp from 'node:child_process'
 import { vi, test, expect } from 'vitest'
 import { type GeckodriverParameters, start } from '../src/index.ts'
+import { download } from '../src/install.js'
 
 test('start', async () => {
     vi.mock('../src/install.js', () =>  {
@@ -38,4 +39,24 @@ test('start', async () => {
             MOZ_HEADLESS_WIDTH: '720'
         }
     })
+})
+
+test('start does not forward geckoDriverVersion as a Geckodriver CLI argument', async () => {
+    vi.mocked(cp.spawn).mockClear()
+    vi.mocked(download).mockClear()
+
+    const args: GeckodriverParameters = {
+        geckoDriverVersion: '0.36.0'
+    }
+
+    await start(args)
+
+    // the version is used to download the correct driver binary...
+    expect(download).toHaveBeenCalledWith('0.36.0', undefined)
+
+    // ...but must not be passed to the Geckodriver executable (it rejects
+    // unknown args, e.g. "unexpected argument '--gecko-driver-version' found")
+    const spawnArgs = vi.mocked(cp.spawn).mock.calls[0][1] as string[]
+    expect(spawnArgs).not.toContain('--gecko-driver-version=0.36.0')
+    expect(spawnArgs.some((arg) => arg.startsWith('--gecko-driver-version'))).toBe(false)
 })


### PR DESCRIPTION
Resolves #https://github.com/webdriverio/webdriverio/issues/15359